### PR TITLE
Fix and improve mypy checks

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,6 +9,9 @@ on:
       - '**.css'
       - '**.lock'
       - 'Makefile'
+  push:
+    branches:
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Install dependencies
         run: poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      - name: Run mypy
+        run: |
+          source $VENV
+          mypy .
       - name: Test with pytest
         run: |
           source $VENV

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Development tools for Textual.
 
+![checks](https://github.com/Textualize/textual-dev/actions/workflows/pythonpackage.yml/badge.svg?event=push)
+
+
 This package contains the `textual` command line app, which will help to develop Textual applications.
 
 See [Getting Started](https://textual.textualize.io/getting_started/) for how to use it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ addopts = "--strict-markers"
 markers = [
     "integration_test: marks tests as slow integration tests (deselect with '-m \"not integration_test\"')",
 ]
+
+[tool.mypy]
+implicit_reexport = false

--- a/src/textual_dev/previews/borders.py
+++ b/src/textual_dev/previews/borders.py
@@ -1,6 +1,8 @@
+from typing import cast
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
 from textual.css.constants import VALID_BORDER
+from textual.css.types import EdgeType
 from textual.widgets import Button, Label
 
 TEXT = """I must not fear.
@@ -60,7 +62,7 @@ class BorderApp(App[None]):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.text.border_title = event.button.id
         self.text.styles.border = (
-            event.button.id,
+            cast(EdgeType, event.button.id),
             self.stylesheet._variables["secondary"],
         )
 

--- a/src/textual_dev/previews/colors.py
+++ b/src/textual_dev/previews/colors.py
@@ -1,5 +1,6 @@
+from textual._color_constants import COLOR_NAME_TO_RGB
 from textual.app import App, ComposeResult
-from textual.color import COLOR_NAME_TO_RGB, Color
+from textual.color import Color
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.design import ColorSystem
 from textual.widgets import Button, Footer, Label, Static, TabbedContent

--- a/src/textual_dev/service.py
+++ b/src/textual_dev/service.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import msgpack
 from aiohttp import WSMsgType
-from aiohttp.abc import Request
+from aiohttp.web_request import Request
 from aiohttp.web_ws import WebSocketResponse
 from rich.console import Console
 from rich.markup import escape

--- a/tests/devtools/test_devtools_client.py
+++ b/tests/devtools/test_devtools_client.py
@@ -8,11 +8,8 @@ import time_machine
 from aiohttp.web_ws import WebSocketResponse
 from rich.console import ConsoleDimensions
 from rich.panel import Panel
-
 from textual.constants import DEVTOOLS_PORT
-from textual_dev.client import DevtoolsClient
-from textual_dev.redirect_output import DevtoolsLog
-
+from textual_dev.client import DevtoolsClient, DevtoolsLog
 from utilities.wait_for_predicate import wait_for_predicate
 
 CALLER_LINENO = 123

--- a/tests/utilities/wait_for_predicate.py
+++ b/tests/utilities/wait_for_predicate.py
@@ -20,7 +20,7 @@ async def wait_for_predicate(
         poll_delay_secs (float): The number of seconds to wait between each call to the
             predicate function.
     """
-    time_taken = 0
+    time_taken = 0.0
     while True:
         result = predicate()
         if result:


### PR DESCRIPTION
### Errors:

    src/textual_dev/previews/borders.py:65: error: Incompatible types in assignment (expression has type "tuple[str, str]", variable has type "Sequence[tuple[Literal['', 'ascii', 'none', 'hidden', 'blank', 'round', 'solid', 'thick', 'double', 'dashed', 'heavy', 'inner', 'outer', 'hkey', 'vkey', 'tall', 'panel', 'wide'], str | Color] | None] | tuple[Literal['', 'ascii', 'none', 'hidden', 'blank', 'round', 'solid', 'thick', 'double', 'dashed', 'heavy', 'inner', 'outer', 'hkey', 'vkey', 'tall', 'panel', 'wide'], str | Color] | None")  [assignment]
    tests/utilities/wait_for_predicate.py:29: error: Incompatible types in assignment (expression has type "float", variable has type "int")  [assignment]

### Disallow implicit reexports

An implicit reexport happens, when a module imports something using the `from ... import ...` pattern, as the imported symbol is visible to the outside world.

This check only allows importing from these modules if the symbol is put in `__all__` or renamed to itself using `from A import B as B`

This check revealed several fishy imports.

See https://mypy.readthedocs.io/en/latest/config_file.html#confval-implicit_reexport

### Run checks on main

Also added status badge to README.