### PR TITLE
Example showing that builds on Windows fail

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ on:
       - 'Makefile'
   push:
     branches:
-      - 'main'
+      - '*'
 
 jobs:
   build:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,3 +8,9 @@ def test_cli_version():
     runner = CliRunner()
     result = runner.invoke(run, ["--version"])
     assert version("textual") in result.output
+
+
+def test_cli_keys():
+    runner = CliRunner()
+    result = runner.invoke(run, ["keys"])
+    assert result.exit_code == 0


### PR DESCRIPTION
This is only example showing that command `textual` or at least its builds [fail on Windows](https://github.com/pavelkraleu/textual-dev/actions/runs/5834484903/job/15824112287#step:8:61).  

Here I only added tests for command `textual keys` which is already implemented but not tested.

This confirms that issues I have encountered in [this PR](https://github.com/Textualize/textual-dev/pull/8) are not caused by my actions 🙂.

Do you have any idea what could be causing this @rodrigogiraoserrao ? For example am I invoking the tests incorrectly? 🙏 

