### PR TITLE
Running textual console produces an error

### DIFF
--- a/src/textual_dev/server.py
+++ b/src/textual_dev/server.py
@@ -51,7 +51,6 @@ def _run_devtools(
             app,
             port=DEVTOOLS_PORT if port is None else port,
             print=noop_print,
-            loop=asyncio.get_event_loop(),
         )
     except OSError:
         from rich import print


### PR DESCRIPTION
When I run  this command `textual console` I get this error.

got an unexpected keyword argument 'loop'

This PR removed the keyword argument from the function call as its not in the signature and the first line of `run_app` create the asyncio loop.