### PR TITLE
Report the correct print location in the console

### DIFF
--- a/src/textual_dev/previews/borders.py
+++ b/src/textual_dev/previews/borders.py
@@ -1,4 +1,5 @@
 from typing import cast
+
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
 from textual.css.constants import VALID_BORDER

--- a/src/textual_dev/previews/easing.py
+++ b/src/textual_dev/previews/easing.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from rich.console import RenderableType
 from textual._easing import EASING
 from textual.app import App, ComposeResult
-from textual_dev.previews.borders import TEXT
 from textual.containers import Horizontal, Vertical
 from textual.reactive import reactive, var
 from textual.scrollbar import ScrollBarRender
 from textual.widget import Widget
 from textual.widgets import Button, Footer, Input, Label
+
+from textual_dev.previews.borders import TEXT
 
 VIRTUAL_SIZE = 100
 WINDOW_SIZE = 10

--- a/src/textual_dev/redirect_output.py
+++ b/src/textual_dev/redirect_output.py
@@ -5,6 +5,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, cast
 
 from textual._log import LogGroup, LogVerbosity
+
 from .client import DevtoolsLog
 
 if TYPE_CHECKING:

--- a/src/textual_dev/tools/diagnose.py
+++ b/src/textual_dev/tools/diagnose.py
@@ -158,7 +158,9 @@ def _console() -> None:
 
 def diagnose() -> None:
     """Print information about Textual and its environment to help diagnose problems."""
-    print("<!-- This is valid Markdown, you can paste the following directly in to a GitHub issue -->")
+    print(
+        "<!-- This is valid Markdown, you can paste the following directly in to a GitHub issue -->"
+    )
     print("# Textual Diagnostics")
     print()
     _versions()

--- a/src/textual_dev/tools/diagnose.py
+++ b/src/textual_dev/tools/diagnose.py
@@ -158,7 +158,9 @@ def _console() -> None:
 
 def diagnose() -> None:
     """Print information about Textual and its environment to help diagnose problems."""
-    print("<!-- This is valid Markdown, please paste the following directly in to a GitHub issue -->")
+    print(
+        "<!-- This is valid Markdown, please paste the following directly in to a GitHub issue -->"
+    )
     print("# Textual Diagnostics")
     print()
     _versions()


### PR DESCRIPTION
~~Fixes https://github.com/Textualize/textual/issues/3237~~

~~I'm undecided about this. It doesn't feel quite right to special-case this, but on the other hand `print` is a form of logging that seems to work differently in Textual vs the normal logging facility (which seems to do its own dance to handle the call location, before it makes it to devtools).~~

~~This does correct the issue, this does ensure that `print` reports the location the same as any `self.log` call. So this is a commit made to solicit more detail on the design decisions in the core of Textual.~~

---

Sets us up to fix https://github.com/Textualize/textual/issues/3237

This PR allows the caller to pass in a frame that should be considered to be the current frame, for the purposes of working out the location of the original log/print. This change alone won't fix https://github.com/Textualize/textual/issues/3237 but provides what's needed for a change to Textual that will allow fixing it.

**IMPORTANT:** If this is an acceptable approach, this code should be merged into `textual-dev` and published first. There is [a corresponding PR for Textual itself](https://github.com/Textualize/textual/pull/3294) that should only be merged and used *after* this version of `textual-dev` is available and able to be used. This PR is backward-compatible so should not cause problems for any existing developer-installations of Textual.