### PR TITLE
Add KDE Konsole to diagnose guess_term

### DIFF
--- a/src/textual_dev/tools/diagnose.py
+++ b/src/textual_dev/tools/diagnose.py
@@ -90,6 +90,12 @@ def _guess_term() -> str:
             term_program = os.environ.get("XTERM_VERSION") or "XTerm"
         elif "TERMINATOR_UUID" in os.environ:
             term_program = "Terminator"
+        elif "KONSOLE_VERSION" in os.environ:
+            term_program = (
+                f"Konsole {os.environ.get('KONSOLE_VERSION')}"
+                if os.environ.get("KONSOLE_VERSION")
+                else "Konsole"
+            )
 
     else:
         # See if we can pull out some sort of version information too.


### PR DESCRIPTION
The Yakuake terminal is based on Konsole and will also display as Konsole