### PR TITLE
Report self version in `--version` (closes textual-dev#20)

### DIFF
--- a/src/textual_dev/cli.py
+++ b/src/textual_dev/cli.py
@@ -15,7 +15,7 @@ WINDOWS = platform.system() == "Windows"
 
 
 @click.group()
-@click.version_option(version("textual"))
+@click.version_option(f"{version('textual')} (textual-dev {version('textual-dev')})")
 def run() -> None:
     pass
 


### PR DESCRIPTION
I'd rather lean towards reusing `textual_dev.__version__` but it seems invalid.