### PR TITLE
fix(keys): disable command palette

### DIFF
--- a/src/textual_dev/previews/keys.py
+++ b/src/textual_dev/previews/keys.py
@@ -35,6 +35,7 @@ class KeysApp(App[None], inherit_bindings=False):
         width: 1fr;
     }
     """
+    ENABLE_COMMAND_PALETTE = False
 
     last_key: var[str | None] = var[Optional[str]](None)
 


### PR DESCRIPTION
Disable the command palette for `textual keys`. Since this tool is designed for debugging keys, pressing `ctrl+p` should just show the key event.