### PR TITLE
fix(keys): initially focus the key log

### DIFF
--- a/src/textual_dev/previews/keys.py
+++ b/src/textual_dev/previews/keys.py
@@ -40,12 +40,12 @@ class KeysApp(App[None], inherit_bindings=False):
 
     def compose(self) -> ComposeResult:
         yield Header()
+        yield KeyLog()
         yield Horizontal(
             Button("Clear", id="clear", variant="warning"),
             Button("Quit", id="quit", variant="error"),
             id="buttons",
         )
-        yield KeyLog()
 
     def on_ready(self) -> None:
         self.query_one(KeyLog).write(Panel(Text.from_markup(INSTRUCTIONS)), expand=True)


### PR DESCRIPTION
When running `textual keys`, currently the 'Clear' button will have initial focus. This can be confusing if you're trying to test the `enter` key with some modifiers, as this might invoke a button press!

This simply re-orders the composed widgets so the key log is initially focussed instead.