### PR TITLE
Textual run not respecting interpreter choice

### DIFF
--- a/src/textual_dev/tools/run.py
+++ b/src/textual_dev/tools/run.py
@@ -105,7 +105,7 @@ def exec_python(args: Sequence[str], environment: dict[str, str]) -> None:
     if WINDOWS:
         subprocess.call([sys.executable, *args], env=environment)
     else:
-        os.execvpe(sys.executable, ["python", *args], environment)
+        os.execve(sys.executable, [sys.executable, *args], environment)
 
 
 def exec_command(


### PR DESCRIPTION
when trying to run a Textual app without activating the envirionment (out of laziness or in scripts) using e.g.
```shell
.venv/bin/textual run main.py
```

it will look up "python" in `$PATH` instead of using the one in `.venv/`. This results in it trying to run the app with the system interpreter and thus not being able to import Textual.
the reason for this is this line of code.
https://github.com/Textualize/textual-dev/blob/6485ab6500fc6881d52ce08f88d74dd3c3f8ba76/src/textual_dev/tools/run.py#L108
Apparently (I didn't know this either)  the executable from args is used, _not_ the one given to `os.execvpe()` , at least on linux, and since that is just "python" it is looked up in `$PATH`.
Also, there is no need to use `execvpe()` instead of `execve()` because `sys.executable` is always absolute