### PR TITLE
fix: close the Client's aio session if the websocket fails to connect

### DIFF
--- a/src/textual_dev/client.py
+++ b/src/textual_dev/client.py
@@ -118,6 +118,8 @@ class DevtoolsClient:
                 f"{self.url}/textual-devtools-websocket"
             )
         except (ClientConnectorError, ClientResponseError):
+            await self.session.close()
+            self.session = None
             raise DevtoolsConnectionError()
 
         log_queue = self.log_queue


### PR DESCRIPTION
closes #49 

Another option is to fix this in Textual itself; you can remove the guard here:

https://github.com/Textualize/textual/blob/3427dbaed666a9af926c711c0eed552260738cd2/src/textual/app.py#L3605-L3606

 and just call `self._disconnect_devtools()`, since that checks for the presence of devtools (but doesn't check if it's connected).

A third option is to call `self_disconnect_devtools()` when handling the exception raised by the connection failure:

https://github.com/Textualize/textual/blob/3427dbaed666a9af926c711c0eed552260738cd2/src/textual/app.py#L3212-L3213